### PR TITLE
Feature/patroni upgrade

### DIFF
--- a/patroni/templates/_helpers.tpl
+++ b/patroni/templates/_helpers.tpl
@@ -14,3 +14,21 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "patroni.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "patroni.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "patroni.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/patroni/templates/endpoints.yaml
+++ b/patroni/templates/endpoints.yaml
@@ -4,9 +4,7 @@ metadata:
   name: {{ template "patroni.fullname" . }}
   labels:
     app: {{ template "patroni.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "patroni.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    application: {{ template "patroni.name" . }}
-    cluster: {{ template "patroni.fullname" . }}
 subsets: []

--- a/patroni/templates/role.yaml
+++ b/patroni/templates/role.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "patroni.fullname" . }}
+  labels:
+    app: {{ template "patroni.name" . }}
+    chart: {{ template "patroni.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources:
+      - endpoints
+      - pods
+    verbs:
+      - patch
+{{- end }}

--- a/patroni/templates/role.yaml
+++ b/patroni/templates/role.yaml
@@ -15,4 +15,10 @@ rules:
       - pods
     verbs:
       - patch
+      - list
+  - apiGroups: [""]
+    resources:
+      - endpoints
+    verbs:
+      - create
 {{- end }}

--- a/patroni/templates/rolebinding.yaml
+++ b/patroni/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "patroni.fullname" . }}
+  labels:
+    app: {{ template "patroni.name" . }}
+    chart: {{ template "patroni.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "patroni.serviceAccountName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "patroni.fullname" . }}
+{{- end }}

--- a/patroni/templates/secret.yaml
+++ b/patroni/templates/secret.yaml
@@ -10,19 +10,9 @@ metadata:
     application: {{ template "patroni.name" . }}
     cluster: {{ template "patroni.fullname" . }}
 type: Opaque
-data:
-  {{ if .Values.credentials.superuser }}
-  password-superuser: {{ .Values.credentials.superuser | b64enc }}
-  {{ else }}
-  password-superuser: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
-  {{ if .Values.credentials.admin }}
-  password-admin: {{ .Values.credentials.admin | b64enc }}
-  {{ else }}
-  password-admin: {{ randAlphaNum 10 | b64enc | quote }}
-  {{ end }}
-  {{ if .Values.credentials.standby }}
-  password-standby: {{ .Values.credentials.standby | b64enc }}
-  {{ else }}
-  password-standby: {{ randAlphaNum 10 | b64enc | quote }}
+stringData:
+  {{ if .Release.IsInstall }}
+  password-admin: {{ randAlphaNum 10 | quote }}
+  password-standby: {{ randAlphaNum 10 | quote }}
+  password-superuser: {{ randAlphaNum 10 | quote }}
   {{ end }}

--- a/patroni/templates/service.yaml
+++ b/patroni/templates/service.yaml
@@ -4,15 +4,13 @@ metadata:
   name: {{ template "patroni.fullname" . }}
   labels:
     app: {{ template "patroni.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "patroni.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    application: {{ template "patroni.name" . }}
-    cluster: {{ template "patroni.fullname" . }}
 spec:
   type: ClusterIP
   ports:
-    - port: 5432
-      targetPort: postgresql
-      name: postgresql
-      protocol: TCP
+  - name: postgresql
+    port: 5432
+    targetPort: postgresql
+    protocol: TCP

--- a/patroni/templates/serviceaccount.yaml
+++ b/patroni/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "patroni.serviceAccountName" . }}
+  labels:
+    app: {{ template "patroni.name" . }}
+    chart: {{ template "patroni.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end }}

--- a/patroni/templates/statefulset.yaml
+++ b/patroni/templates/statefulset.yaml
@@ -28,7 +28,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: DEBUG
-              value: .Values.debug
+              value: {{ .Values.debug | quote }}
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/patroni/templates/statefulset.yaml
+++ b/patroni/templates/statefulset.yaml
@@ -1,27 +1,28 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "patroni.fullname" . }}
   labels:
     app: {{ template "patroni.name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    chart: {{ template "patroni.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    application: {{ template "patroni.name" . }}
-    cluster: {{ template "patroni.fullname" . }}
 spec:
   serviceName: {{ template "patroni.fullname" . }}
   replicas: {{ .Values.replicas }}
   updateStrategy:
     type: RollingUpdate
+  selector:
+    matchLabels:
+      app: {{ template "patroni.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ template "patroni.name" . }}
         release: {{ .Release.Name }}
-        application: {{ template "patroni.name" . }}
-        cluster: {{ template "patroni.fullname" . }}
     spec:
+      serviceAccountName: {{ template "patroni.serviceAccountName" . }}
       containers:
         - name: spilo
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
@@ -55,9 +56,9 @@ spec:
                     application: {{ template "patroni.name" . }}
                     cluster: {{ template "patroni.fullname" . }}
                   scope_label: cluster
-                postgresql:               
+                postgresql:
 {{ toYaml .Values.postgresParameters | indent 18 }}
-                bootstrap:               
+                bootstrap:
 {{ toYaml .Values.bootstrapParameters | indent 18 }}
             - name: SCOPE
               value: {{ template "patroni.fullname" . }}
@@ -135,7 +136,7 @@ spec:
               name: postgresql
               protocol: TCP
           resources:
-{{ toYaml .Values.resources | indent 12 }}           
+{{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
             - name: datadir
               mountPath: /home/postgres/pgdata

--- a/patroni/templates/statefulset.yaml
+++ b/patroni/templates/statefulset.yaml
@@ -12,6 +12,8 @@ metadata:
 spec:
   serviceName: {{ template "patroni.fullname" . }}
   replicas: {{ .Values.replicas }}
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -55,6 +57,8 @@ spec:
                   scope_label: cluster
                 postgresql:               
 {{ toYaml .Values.postgresParameters | indent 18 }}
+                bootstrap:               
+{{ toYaml .Values.bootstrapParameters | indent 18 }}
             - name: SCOPE
               value: {{ template "patroni.fullname" . }}
             - name: PGPASSWORD_SUPERUSER

--- a/patroni/values.yaml
+++ b/patroni/values.yaml
@@ -93,3 +93,4 @@ rbac:
 # Create ServiceAccount for patroni
 serviceAccount:
   create: true
+  name: "patroni-service-account"

--- a/patroni/values.yaml
+++ b/patroni/values.yaml
@@ -28,7 +28,7 @@ resources: {}
 #     cpu: 2
 #     memory: 7.5Gi
 
-useConfigMaps: true
+useConfigMaps: false
 
 postgresParameters:
   bin_dir: /usr/lib/postgresql/9.6/bin

--- a/patroni/values.yaml
+++ b/patroni/values.yaml
@@ -28,16 +28,27 @@ resources: {}
 #     cpu: 2
 #     memory: 7.5Gi
 
-credentials:
-  # Leave blank to autogenerate
-  superuser:
-  admin:
-  standby:
-
-useConfigMaps: false
+useConfigMaps: true
 
 postgresParameters:
   bin_dir: /usr/lib/postgresql/9.6/bin
+  # pg_hba:
+  #   - local   all             all                                   trust
+  #   - hostssl all             +zalandos    127.0.0.1/32       pam
+  #   - host    all             all                127.0.0.1/32       md5
+  #   - hostssl all             +zalandos    ::1/128            pam
+  #   - host    all             all                ::1/128            md5
+  #   - hostssl replication     standby all                md5
+  #   - hostnossl all           all                all                reject
+  #   - hostssl all             +zalandos    all                pam
+  #   - hostssl all             all                all                md5
+
+# To modify the bootstrap parameters
+bootstrapParameters:
+  dcs:
+    ttl: 70
+    loop_wait: 10
+    retry_timeout: 30
 
 walE:
   enable: false
@@ -46,7 +57,7 @@ walE:
   retainBackups: 2
   s3Bucket:
   kubernetesSecret:
-  gcsBucket: 
+  gcsBucket: # the bucket name created with rdeploy create_bucket
   backupThresholdMegabytes: 1024
   backupThresholdPercentage: 30
 

--- a/patroni/values.yaml
+++ b/patroni/values.yaml
@@ -86,3 +86,10 @@ cleanup:
     repository: quay.io/coreos/hyperkube
     tag: v1.8.4_coreos.0
     pullPolicy: IfNotPresent
+
+## Create RBAC policy for patroni
+rbac:
+  create: true
+# Create ServiceAccount for patroni
+serviceAccount:
+  create: true

--- a/patroni/values.yaml
+++ b/patroni/values.yaml
@@ -93,4 +93,4 @@ rbac:
 # Create ServiceAccount for patroni
 serviceAccount:
   create: true
-  name: "patroni-service-account"
+  name:


### PR DESCRIPTION
This branch requires more testing on `rehive-services-staging`.
The following tests were successful on `docker-for-desktop`. 

- [x] standby, admin and superuser password persist on upgrade
- [x] config changes updated to `postgres.yml` via the `values.yaml` file.

Tests to check:
- [x] Successful migration. 